### PR TITLE
Update state.js.stub

### DIFF
--- a/src/stubs/store/state.js.stub
+++ b/src/stubs/store/state.js.stub
@@ -1,4 +1,4 @@
-export default {
+export default () => ({
     feature: {
         // id: null,
         // propA: null,
@@ -7,4 +7,4 @@ export default {
         // relatedEntities: [],
         // relatedNestedEntities: []
     }
-};
+});


### PR DESCRIPTION
State will export a closure returning the initial state object.

While it did originally work as-is, whenever you enable strict mode on the store during development, each and every state mutation will throw warnings and errors. This is because the `state.js` generated by the package returns a raw object. This fixes that behavior, making the output Vuex.Store strict mode compatible.